### PR TITLE
Fixes NameError: uninitialized constant YAML

### DIFF
--- a/factorish.rb
+++ b/factorish.rb
@@ -1,3 +1,5 @@
+require 'yaml'
+
 FACTORISH_SETTINGS = ENV['FACTORISH_SETTINGS'] || 'factorish.yml'
 
 SETTINGS = YAML.load_file(FACTORISH_SETTINGS)['factorish']


### PR DESCRIPTION
Received this error the very first time I ran `vagrant up`. This fixes the issue.
