### PR TITLE
Fix issue where failed node cannot join back to cluster 

### DIFF
--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -12,6 +12,7 @@ WORKDIR /tmp
 
 # Base Deps
 RUN \
+  echo "Europe/Budapest" > /etc/timezone; dpkg-reconfigure -f noninteractive tzdata && \
   apt-key adv --keyserver keys.gnupg.net --recv-keys 8507EFA5 && \
   echo "deb http://repo.percona.com/apt jessie main" > /etc/apt/sources.list.d/percona.list && \
   echo "deb-src http://repo.percona.com/apt jessie main" >> /etc/apt/sources.list.d/percona.list && \

--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -12,11 +12,12 @@ WORKDIR /tmp
 
 # Base Deps
 RUN \
-  apt-key adv --keyserver keys.gnupg.net --recv-keys 1C4CBDCDCD2EFD2A && \
+  apt-key adv --keyserver keys.gnupg.net --recv-keys 8507EFA5 && \
   echo "deb http://repo.percona.com/apt jessie main" > /etc/apt/sources.list.d/percona.list && \
   echo "deb-src http://repo.percona.com/apt jessie main" >> /etc/apt/sources.list.d/percona.list && \
   ln -fs /bin/true /usr/bin/chfn && \
   apt-get -yqq update && \
+  apt-get dist-upgrade -y && \
   apt-get install -yqq \
   ca-certificates \
   curl \

--- a/database/bin/boot
+++ b/database/bin/boot
@@ -54,7 +54,9 @@ mkdir -p /etc/service/confd
 init_confd
 
 # initialize data volume
-init_database
+if [[ $BOOTSTRAP == "1" ]]; then
+  init_database
+fi
 
 # check to see if cluster is already active
 if [[ -z $CLUSTER_MEMBERS ]]; then

--- a/database/bin/boot
+++ b/database/bin/boot
@@ -3,11 +3,16 @@
 # This script is designed to be run inside the container
 #
 
+
 # fail hard and fast even on pipelines
 set -eo pipefail
 
 # set debug based on envvar
 [[ -n $DEBUG ]] && set -x
+
+# update packages on every boot
+apt-get -yqq update && \
+apt-get dist-upgrade -y
 
 DIR=$(dirname $0)
 

--- a/database/bin/functions
+++ b/database/bin/functions
@@ -69,7 +69,7 @@ function mysql_creds() {
   mysql -e "SET wsrep_on=OFF; GRANT ALL ON *.* TO '$REP_USER'@'localhost' IDENTIFIED BY '$REP_PASS';"
   mysql -e "SET wsrep_on=OFF; GRANT ALL PRIVILEGES ON *.* TO '$MYSQL_USER'@'%' IDENTIFIED BY '$MYSQL_PASS';"
   mysql -e "SET wsrep_on=OFF; GRANT SUPER ON *.* TO '$MYSQL_USER'@'%' WITH GRANT OPTION;"
-  mysql -e 'FLUSH PRIVILEGES;'
+  mysql -e "SET wsrep_on=OFF; FLUSH PRIVILEGES;"
 }
 
 function configure_etcd() {


### PR DESCRIPTION
Fix issue where failed node cannot join back to cluster because docker init phase generates one extra transaction. It turns out the FLUSH PRIVILEGES will push the transaction id in grastate.dat and will result in this issue:
2016-06-28 08:14:16 1899 [ERROR] WSREP: gcs/src/gcs_group.cpp:group_post_state_exchange():321: Reversing history: 935 -> 934, this member has applied 1 more events than the primary component.Data loss is possible. Aborting.
